### PR TITLE
Fix PHP 7-incompatible call to split()

### DIFF
--- a/CRM/Segmentation/Exporter.php
+++ b/CRM/Segmentation/Exporter.php
@@ -474,7 +474,7 @@ abstract class CRM_Segmentation_Exporter {
     if ($prefix == 'custom_') {
       $suffix = substr($field_name, 7);
       if (!is_numeric($suffix)) {
-        $path = split("\\.", $suffix);
+        $path = preg_split("\\.", $suffix);
         $field = NULL;
         if (count($path) == 1) {
           $field = $this->getField($field_name, array('name' => $path[0]));

--- a/CRM/Segmentation/Exporter.php
+++ b/CRM/Segmentation/Exporter.php
@@ -474,7 +474,7 @@ abstract class CRM_Segmentation_Exporter {
     if ($prefix == 'custom_') {
       $suffix = substr($field_name, 7);
       if (!is_numeric($suffix)) {
-        $path = preg_split("\\.", $suffix);
+        $path = preg_split("/\./", $suffix);
         $field = NULL;
         if (count($path) == 1) {
           $field = $this->getField($field_name, array('name' => $path[0]));


### PR DESCRIPTION
This replaces a call to `split()`, which was removed in PHP 7, with `preg_split()`.