### PR TITLE
Fix country being exported as name instead of ISO in TM file

### DIFF
--- a/resources/default_exporters.json
+++ b/resources/default_exporters.json
@@ -398,6 +398,21 @@
       {
         "action": "copy",
         "from": "contact.country",
+        "to": "Land_Name"
+      },
+      {
+        "action": "load",
+        "to": "country",
+        "type": "Country",
+        "cached": true,
+        "params": {
+          "id": "var:contact.country_id",
+          "return": "iso_code"
+        }
+      },
+      {
+        "action": "copy",
+        "from": "country.iso_code",
         "to": "Land"
       },
       {


### PR DESCRIPTION
This changes the TM export file to use ISO codes instead of the country name.