### PR TITLE
Add permission to 'segmentation_order' api

### DIFF
--- a/segmentation.php
+++ b/segmentation.php
@@ -116,6 +116,7 @@ function segmentation_civicrm_alterAPIPermissions($entity, $action, &$params, &$
   $permissions['segmentation']['segmentlist'] = array('manage campaign');
   $permissions['segmentation']['getsegmentid'] = array('manage campaign');
   $permissions['segmentationorder']['create'] = array('manage campaign');
+  $permissions['segmentation_order']['update'] = array('manage campaign');
 }
 
 /**


### PR DESCRIPTION
This adds a permission that makes the `SegmentationOrder.update` API available to anyone with the "manage campaign" permission.

Upstream of https://github.com/greenpeace-cee/de.systopia.segmentation/pull/1.