### PR TITLE
Add drag-and-drop functionality to 'Start Campaign' page

### DIFF
--- a/CRM/Segmentation/Page/Start.php
+++ b/CRM/Segmentation/Page/Start.php
@@ -16,7 +16,7 @@
 
 /**
  * This page manages starting a campaign,
- * i.e. chaging the status from "planned" to "running"
+ * i.e. changing the status from "planned" to "running"
  *   which includes considating and freezing the segments.
  */
 class CRM_Segmentation_Page_Start extends CRM_Core_Page {
@@ -67,16 +67,20 @@ class CRM_Segmentation_Page_Start extends CRM_Core_Page {
     $this->assign('campaign_id', $campaign['id']);
     $this->assign('total_count', $total_count);
     CRM_Utils_System::setTitle(ts("Start Campaign '%1'", array(1 => $campaign['title'])));
+    CRM_Core_Resources::singleton()->addScriptFile('de.systopia.segmentation', 'js/SortSegments.js');
+    CRM_Core_Resources::singleton()->addStyleFile('de.systopia.segmentation', 'css/segmentation_start_page.css');
 
     parent::run();
   }
 
-
   /**
-   * process any ordering commands to modify the given segment_order
+   * Process any ordering commands to modify the given segment_order
    *
-   * @param $segment_order  the current segment order
-   * @return the new segment order
+   * @param $segment_order(the current segment order)
+   *
+   * @return array(the new segment order)
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function processOrderCommands($segment_order) {
     foreach (array('top', 'up', 'down', 'bottom') as $cmd) {
@@ -109,6 +113,10 @@ class CRM_Segmentation_Page_Start extends CRM_Core_Page {
   /**
    * Process a delete command if there is one,
    * deleting an entire segment
+   *
+   * @param $campaign_id
+   *
+   * @throws \CRM_Core_Exception
    */
   protected function processDeleteCommand($campaign_id) {
     if (empty($campaign_id)) return;
@@ -133,7 +141,8 @@ class CRM_Segmentation_Page_Start extends CRM_Core_Page {
           AND `segment_id`  = {$segment_id}");
 
       // create notice
-      CRM_Core_Session::setStatus(ts("Segment sucessfully removed."), ts("Success"), "info");
+      CRM_Core_Session::setStatus(ts("Segment successfully removed."), ts("Success"), "info");
     }
   }
+
 }

--- a/api/v3/Segmentation/Sort.php
+++ b/api/v3/Segmentation/Sort.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Updates the order of the segment items
+ *
+ * @param $params
+ *
+ * @return array
+ */
+function civicrm_api3_segmentation_sort($params) {
+  $campaign = new CRM_Campaign_BAO_Campaign();
+  $campaign->id = $params['campaign_id'];
+  if (empty($campaign->find(TRUE))) {
+    return civicrm_api3_create_error('Campaign(id=' . $params['campaign_id'] . ') does not exist.');
+  }
+
+  if (!is_array($params['new_order_of_segments'])) {
+    return civicrm_api3_create_error('Field "new_order_of_segments" must be array of "segment" ids.');
+  }
+
+  $campaignId = $params['campaign_id'];
+  $newOrderOfSegment = $params['new_order_of_segments'];
+  $currentOrderOfSegment = CRM_Segmentation_Logic::getSegmentOrder($campaignId);
+
+  $parsedNewOrderOfSegment = [];
+  foreach ($newOrderOfSegment as $segmentId) {
+    $parsedNewOrderOfSegment[] = (int) $segmentId;
+  }
+
+  if (_segmentation_is_valid_new_order_of_segment($currentOrderOfSegment, $parsedNewOrderOfSegment)) {
+    return civicrm_api3_create_error('Field "new_order_of_segments" is invalid. The field must be array of "segment" ids.');
+  }
+
+  CRM_Segmentation_Logic::setSegmentOrder($campaignId, $parsedNewOrderOfSegment);
+
+  return civicrm_api3_create_success(['Order have successfully modified.']);
+}
+
+/**
+ * Checks if entered(field 'new_order_of_segments') ids of segments and
+ * ids of segments from database is equal
+ *
+ * @param $currentOrder
+ * @param $newOrder
+ *
+ * @return bool
+ */
+function _segmentation_is_valid_new_order_of_segment($currentOrder, $newOrder) {
+  sort($currentOrder);
+  sort($newOrder);
+
+  return $currentOrder != $newOrder;
+}
+
+/**
+ * This is used for documentation and validation.
+ *
+ * @param array $params description of fields supported by this API call
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_segmentation_sort_spec(&$params) {
+  $params['new_order_of_segments'] = [
+    'name'         => 'new_order_of_segments',
+    'api.required' => 1,
+    'type'         => CRM_Utils_Type::T_STRING,
+    'title'        => 'New order of segment',
+    'description'  => 'Array of new segments(id) order. Example: [1, 2, 3].',
+  ];
+
+  $params['campaign_id'] = [
+    'name'         => 'campaign_id',
+    'api.required' => 1,
+    'type'         => CRM_Utils_Type::T_INT,
+    'title'        => 'Campaign id',
+    'description'  => 'Campaign id',
+  ];
+}

--- a/css/segmentation_start_page.css
+++ b/css/segmentation_start_page.css
@@ -1,0 +1,22 @@
+.sort-segments-btn {
+    cursor: pointer;
+    text-align: center;
+    vertical-align: middle !important;
+}
+
+.sort-segments-btn-ico {
+    display: inline-block;
+}
+
+.sort-segments-btn.is-moving {
+    cursor: grabbing;
+}
+
+.ui-state-highlight {
+    height: 30px;
+    width: 100%;
+    border: 2px solid #4999DA;
+    margin: 0 0 0.75rem 0;
+    position: relative;
+    z-index: 6;
+}

--- a/js/SortSegments.js
+++ b/js/SortSegments.js
@@ -1,0 +1,42 @@
+cj(document).ready(function () {
+
+  initDragAndDrop();
+
+  function initDragAndDrop() {
+    var segmentsTableWrap = cj("#segmentsTableWrap");
+    if (segmentsTableWrap.length !== 1) {
+      console.warn("Can't init drag and drop.");
+      return;
+    }
+
+    var campaignId = segmentsTableWrap.data('campaign-id');
+    var sortable = segmentsTableWrap.sortable({
+      placeholder: "ui-state-highlight",
+      handle: '.sort-segments-btn',
+      forceHelperSize: true,
+      items: '.sorting-init',
+      update: function (event, ui) {
+        var newOrder = [];
+
+        sortable.find('tr').each(function () {
+          var id = cj(this).data('segmentation-id');
+          if (id) newOrder.push(parseInt(id, 10));
+        });
+
+        CRM.api3('Segmentation', 'sort', {
+          "sequential": 1,
+          "campaign_id": campaignId,
+          "new_order_of_segments": newOrder
+        }).done(function (result) {
+          if (result.is_error == 1) {
+            alert('The following error occured: ' + result.error_message);
+            window.location.reload();
+          }
+        }).fail(function (result) {
+          console.log('fail: ' + result);
+        });
+      }
+    });
+  }
+
+});

--- a/templates/CRM/Segmentation/Page/Start.tpl
+++ b/templates/CRM/Segmentation/Page/Start.tpl
@@ -36,11 +36,12 @@
       <th>{ts}Text Block{/ts}</th>
       <th>{ts}Segment Order{/ts}</th>
       <th>{ts}Actions{/ts}</th>
+      <th>{ts}Sort{/ts}</th>
     </tr>
   </thead>
-  <tbody>
+  <tbody id="segmentsTableWrap" data-campaign-id="{$campaign_id}">
   {foreach from=$segments item=segment}
-    <tr id="SegmentationOrder-{$segment.segmentation_order_id}" data-action="create" class="crm-entity even-row">
+    <tr id="SegmentationOrder-{$segment.segmentation_order_id}" data-segmentation-id="{$segment.segment_id}" data-action="create" class="crm-entity even-row sorting-init">
       <td class="crm-admin-options-label" data-field="label">
         <div class="" title="{$segment.name|escape}">{$segment.name|escape}</div>
       </td>
@@ -67,6 +68,9 @@
         </a>
         {/if}
       </td>
+      <td class="sort-segments-btn">
+        <div class="sort-segments-btn-ico">&#8693;</div>
+      </td>
     </tr>
   {/foreach}
   </tbody>
@@ -75,9 +79,6 @@
 <div>
   <a href="{crmURL p='civicrm/segmentation/start' q="cid=$campaign_id&start=now"}" class="button"><span>{ts}Start Campaign{/ts}</span></a>
 </div>
-
-
-
 
 <script type="text/javascript">
 // reset the URL


### PR DESCRIPTION
This adds a drag-and-drop interface to the "Start Campaign" page to make it easier to change the order of segments.

![demo](https://user-images.githubusercontent.com/277794/66561028-ea2d5680-eb58-11e9-9c18-e951b377c94f.gif)