### PR TITLE
GP-8694 Add missing permission for Segmentation.sort API

### DIFF
--- a/segmentation.php
+++ b/segmentation.php
@@ -117,6 +117,7 @@ function segmentation_civicrm_alterAPIPermissions($entity, $action, &$params, &$
   $permissions['segmentation']['getsegmentid'] = array('manage campaign');
   $permissions['segmentationorder']['create'] = array('manage campaign');
   $permissions['segmentation_order']['update'] = array('manage campaign');
+  $permissions['segmentation']['sort'] = array('manage campaign');
 }
 
 /**


### PR DESCRIPTION
This adds a missing permission for the `Segmentation.sort` API.